### PR TITLE
Custamizable isearch keybinding

### DIFF
--- a/migemo.el
+++ b/migemo.el
@@ -69,8 +69,9 @@
   :type 'boolean)
 
 (defcustom migemo-use-default-isearch-keybinding t
-  "*If non-nil, set migemo default keybinding for isearch"
-  :group 'migemo)
+  "*If non-nil, set migemo default keybinding for isearch in `migemo-init'."
+  :group 'migemo
+  :type 'boolean)
 
 (defcustom migemo-dictionary (expand-file-name "migemo-dict" migemo-directory)
   "*Migemo dictionary file."


### PR DESCRIPTION
I replaced a not good use of hook to register isearch keybinding.
That was the root of less customizability because
1. nameless function can't be remove by `remove-hook';
2. body, defining keybiding, called each time isearch starts.
    For example,
      (define-key isearch-mode-map "\C-y" nil)
    in .emacs file has no effect. (Overrided by the hook.)
