### PR TITLE
Fix multiline search with C/Migemo

### DIFF
--- a/migemo.el
+++ b/migemo.el
@@ -169,6 +169,7 @@
 (defvar migemo-search-pattern-alist nil)
 (defvar migemo-do-isearch nil)
 (defvar migemo-register-isearch-keybinding-function nil)
+(defvar migemo-process-insertion-pattern nil)
 
 ;; For warnings of byte-compile. Following functions are defined in XEmacs
 (declare-function set-process-input-coding-system "code-process")
@@ -214,6 +215,10 @@
   (when (and migemo-use-default-isearch-keybinding
              migemo-register-isearch-keybinding-function)
     (funcall migemo-register-isearch-keybinding-function))
+  (setq migemo-process-insertion-pattern
+        (if (string-match "cmigemo" migemo-command)
+            "\\s-*"
+          "\a"))
   (or (and migemo-process
 	   (eq (process-status migemo-process) 'run))
       (let ((options
@@ -286,7 +291,9 @@
       (if (and migemo-after-conv-function
 	       (functionp migemo-after-conv-function))
 	  (funcall migemo-after-conv-function word pattern)
-	(migemo-replace-in-string pattern "\a" migemo-white-space-regexp))))))
+	(migemo-replace-in-string pattern
+                                  migemo-process-insertion-pattern
+                                  migemo-white-space-regexp))))))
 
 (defun migemo-pattern-alist-load (file)
   "Load migemo alist file."


### PR DESCRIPTION
検索する文字数が少なくて C/Migemo の返すパターンが大きくなる場合に

```
Error running timer `isearch-lazy-highlight-update': (invalid-regexp "Unmatched [ or [^")
```

というエラーになることがあります。再現手順は以下の通りです。
1. emacs -Q で起動
2. migemo.el のあるディレクトリを load-path に追加
3. cmigemo コマンドのあるディレクトリを exec-path に追加
4. migemo-dictionary を確認して README.md の設定例を評価
5. `C-s` 後 `k` だけタイプして検索

OS X Yosemite の Emacs 24.4 だとエラーにならない場合もありますが何度か試すと再現します。Mac port 5.2 だとよく再現します。

C/Migemo HEAD では C/Migemo の返すパターンの中に `\n` が含まれるようになっていますが、migemo.el の migemo-get-pattern 関数では `\n`  をパターンの終端判定に使っているためパターンが壊れているように思います。

migemo-get-pattern ではすでに Ruby/Migemo 用として `\a` を置換しているので、C/Migemo の koron/cmigemo@e5aeae17daa16f0e2b8dc200ee8093c2bc7a89fe は revert して C/Migemo でも同じところで置換するというのはどうでしょうか。
