### PR TITLE
Change Encoding: utf-8-unix, ...

### DIFF
--- a/migemo.el
+++ b/migemo.el
@@ -5,7 +5,7 @@
 
 ;; Author: Satoru Takabayashi <satoru-t@is.aist-nara.ac.jp>
 ;; URL: https://github.com/emacs-jp/migemo
-;; Version: 1.9.1
+;; Version: 1.9.2
 ;; Keywords:
 ;; Package-Requires: ((cl-lib "0.5"))
 
@@ -36,34 +36,33 @@
   "migemo - Japanese incremental search trough dynamic pattern expansion."
   :group 'matching)
 
-(defcustom migemo-command "ruby"
+(defcustom migemo-command "cmigemo"
   "*Name or full path of the executable for running migemo."
   :group 'migemo
-  :type '(choice (const :tag "Ruby Migemo" "ruby")
-		 (const :tag "CMIGEMO" "cmigemo")
-		 (string :tag "Other")))
+  :type '(choice
+          (const :tag "CMIGEMO" "cmigemo")
+          (const :tag "Ruby Migemo" "ruby")
+          (string :tag "Other")))
 
-;; -t emacs for specifying the type of regular expression.
-;;  "-i" "\a" for searching a word over multi-lines.
-(defcustom migemo-options '("-S" "migemo" "-t" "emacs"  "-i" "\a")
+(defcustom migemo-options '("-q" "--emacs")
   "*Options for migemo command."
   :group 'migemo
   :type '(repeat string))
 
-(defcustom migemo-white-space-regexp "[ °°\t\r\n]*"
+(defcustom migemo-white-space-regexp "[ „ÄÄ\t\r\n]*"
   "*Regexp representing white spaces."
   :group 'migemo
   :type 'string)
 
-;; for C/Migemo
-;; (setq migemo-command "cmigemo")
-;; (setq migemo-options '("-q" "--emacs" "-i" "\g"))
-;; (setq migemo-dictionary "somewhere/migemo/euc-jp/migemo-dict")
+;; for Ruby/Migemo
+;; (setq migemo-command "ruby")
+;; (setq migemo-options '("-S" "migemo" "-t" "emacs" "-i" "\a"))
+;; (setq migemo-dictionary "somewhere/migemo/utf-8/migemo-dict")
 ;; (setq migemo-user-dictionary nil)
 ;; (setq migemo-regex-dictionary nil))
 
-(defcustom migemo-directory "@pkgdatadir@"
-  "*Directory where migemo files are placed"
+(defcustom migemo-directory nil
+  "*Directory where migemo files are placed."
   :group 'migemo
   :type 'directory)
 
@@ -85,38 +84,33 @@
 (defcustom migemo-user-dictionary (expand-file-name "user-dict" migemo-directory)
   "*Migemo user dictionary file."
   :group 'migemo
-  :type '(choice (file :must-match t)
-		 (const :tag "Do not use" nil)))
+  :type '(choice
+          (file :must-match t)
+          (const :tag "Do not use" nil)))
 
 (defcustom migemo-regex-dictionary (expand-file-name "regex-dict" migemo-directory)
   "*Migemo regex dictionary file."
   :group 'migemo
-  :type '(choice (file :must-match t)
-		 (const :tag "Do not use" nil)))
+  :type '(choice
+          (file :must-match t)
+          (const :tag "Do not use" nil)))
 
 (defcustom migemo-pre-conv-function nil
   "*Function of migemo pre-conversion."
   :group 'migemo
-  :type '(choice (const :tag "Do not use" nil)
-		 function))
+  :type '(choice
+          (const :tag "Do not use" nil)
+          function))
 
 (defcustom migemo-after-conv-function nil
   "*Function of migemo after-conversion."
   :group 'migemo
-  :type '(choice (const :tag "Do not use" nil)
-		 function))
+  :type '(choice
+          (const :tag "Do not use" nil)
+          function))
 
-(defcustom migemo-coding-system
-  (with-no-warnings
-    (if (>= emacs-major-version 20)
-        (if (featurep 'mule)
-            (if (string-match "XEmacs" emacs-version)
-                (cond
-                 ((memq 'euc-japan-unix (coding-system-list)) 'euc-japan-unix)
-                 ((memq 'euc-jp-unix (coding-system-list)) 'euc-jp-unix))
-              'euc-japan-unix))
-      (and (boundp 'MULE) *euc-japan*unix)))
-  "*Default coding system for migemo.el"
+(defcustom migemo-coding-system 'utf-8-unix
+  "*Default coding system for migemo.el."
   :group 'migemo
   :type 'coding-system)
 
@@ -135,12 +129,12 @@
   :group 'migemo
   :type 'integer)
 
-(defcustom migemo-pattern-alist-file "~/.migemo-pattern"
+(defcustom migemo-pattern-alist-file (expand-file-name ".migemo-pattern" user-emacs-directory)
   "*Path of migemo alist file. If nil, don't save and restore the file."
   :group 'migemo
   :type 'file)
 
-(defcustom migemo-frequent-pattern-alist-file "~/.migemo-frequent"
+(defcustom migemo-frequent-pattern-alist-file (expand-file-name ".migemo-frequent" user-emacs-directory)
   "*Path of migemo frequent alist file. If nil, don't save and restore the file."
   :group 'migemo
   :type 'file)
@@ -155,9 +149,6 @@
   :group 'migemo
   :type 'integer)
 
-(defconst migemo-mw32-input-method (and (featurep 'meadow) "MW32-IME")
-  "Support \"MW32-IME\" for Meadow.")
-
 ;; internal variables
 (defvar migemo-process nil)
 (defvar migemo-buffer nil)
@@ -167,7 +158,6 @@
 (defvar migemo-search-pattern nil)
 (defvar migemo-pattern-alist nil)
 (defvar migemo-frequent-pattern-alist nil)
-(defconst migemo-emacs21p (and (> emacs-major-version 20) (not (featurep 'xemacs))))
 (defvar migemo-search-pattern-alist nil)
 (defvar migemo-do-isearch nil)
 (defvar migemo-register-isearch-keybinding-function nil)
@@ -181,59 +171,59 @@
     (unless pattern
       (setq pattern (migemo-get-pattern string))
       (setq migemo-search-pattern-alist
-	    (cons (cons string pattern)
-		  migemo-search-pattern-alist)))
+        (cons (cons string pattern)
+          migemo-search-pattern-alist)))
     pattern))
 
 (defun migemo-toggle-isearch-enable ()
   (interactive)
   (setq migemo-isearch-enable-p (not migemo-isearch-enable-p))
   (message (if migemo-isearch-enable-p
-	       "t"
-	     "nil")))
+           "t"
+         "nil")))
 
 (defun migemo-start-process (name buffer program args)
   (let* ((process-connection-type nil)
          (proc (apply 'start-process name buffer program args)))
     (if (fboundp 'set-process-coding-system)
-	(set-process-coding-system proc
-				   migemo-coding-system
-				   migemo-coding-system)
+        (set-process-coding-system proc
+                                   migemo-coding-system
+                                   migemo-coding-system)
       (set-process-input-coding-system  proc migemo-coding-system)
       (set-process-output-coding-system proc migemo-coding-system))
     proc))
 
 (defun migemo-init ()
   (when (and migemo-use-frequent-pattern-alist
-	     migemo-frequent-pattern-alist-file
-	     (null migemo-frequent-pattern-alist))
+         migemo-frequent-pattern-alist-file
+         (null migemo-frequent-pattern-alist))
     (setq migemo-frequent-pattern-alist
-	  (migemo-pattern-alist-load migemo-frequent-pattern-alist-file)))
+      (migemo-pattern-alist-load migemo-frequent-pattern-alist-file)))
   (when (and migemo-use-pattern-alist
-	     migemo-pattern-alist-file
-	     (null migemo-pattern-alist))
+         migemo-pattern-alist-file
+         (null migemo-pattern-alist))
     (setq migemo-pattern-alist
-	  (migemo-pattern-alist-load migemo-pattern-alist-file)))
+      (migemo-pattern-alist-load migemo-pattern-alist-file)))
   (when (and migemo-use-default-isearch-keybinding
              migemo-register-isearch-keybinding-function)
     (funcall migemo-register-isearch-keybinding-function))
   (or (and migemo-process
-	   (eq (process-status migemo-process) 'run))
+       (eq (process-status migemo-process) 'run))
       (let ((options
-	     (delq nil
-		   (append migemo-options
-			   (when (and migemo-user-dictionary
-				      (file-exists-p migemo-user-dictionary))
-			     (list "-u" migemo-user-dictionary))
-			   (when (and migemo-regex-dictionary
-				      (file-exists-p migemo-regex-dictionary))
-			     (list "-r" migemo-regex-dictionary))
-			   (list "-d" migemo-dictionary)))))
-	(setq migemo-buffer (get-buffer-create " *migemo*"))
-	(setq migemo-process (migemo-start-process
-			      "migemo" migemo-buffer migemo-command options))
-	(set-process-query-on-exit-flag migemo-process nil)
-	t)))
+         (delq nil
+           (append migemo-options
+               (when (and migemo-user-dictionary
+                      (file-exists-p migemo-user-dictionary))
+                 (list "-u" migemo-user-dictionary))
+               (when (and migemo-regex-dictionary
+                      (file-exists-p migemo-regex-dictionary))
+                 (list "-r" migemo-regex-dictionary))
+               (list "-d" migemo-dictionary)))))
+    (setq migemo-buffer (get-buffer-create " *migemo*"))
+    (setq migemo-process (migemo-start-process
+                  "migemo" migemo-buffer migemo-command options))
+    (set-process-query-on-exit-flag migemo-process nil)
+    t)))
 
 (defun migemo-replace-in-string (string from to)
   (with-temp-buffer
@@ -253,43 +243,43 @@
       (set-text-properties 0 (length word) nil word)
       (migemo-init)
       (when (and migemo-pre-conv-function
-		 (functionp migemo-pre-conv-function))
-	(setq word (funcall migemo-pre-conv-function word)))
+         (functionp migemo-pre-conv-function))
+    (setq word (funcall migemo-pre-conv-function word)))
       (setq pattern
-	    (cond
-	     ((setq freq (and migemo-use-frequent-pattern-alist
-			      (assoc word migemo-frequent-pattern-alist)))
-	      (cdr freq))
-	     ((setq alst (and migemo-use-pattern-alist
-			      (assoc word migemo-pattern-alist)))
-	      (setq migemo-pattern-alist (cons alst (delq alst migemo-pattern-alist)))
-	      (cdr alst))
-	     (t
-	      (with-current-buffer (process-buffer migemo-process)
-		(delete-region (point-min) (point-max))
-		(process-send-string migemo-process (concat word "\n"))
-		(while (not (and (> (point-max) 1)
-				 (eq (char-after (1- (point-max))) ?\n)))
-		  (accept-process-output migemo-process
-					 0 migemo-accept-process-output-timeout-msec))
-		(setq pattern (buffer-substring (point-min) (1- (point-max)))))
-	      (when (and (memq system-type '(windows-nt OS/2 emx))
-			 (> (length pattern) 1)
-			 (eq ?\r (aref pattern (1- (length pattern)))))
-		(setq pattern (substring pattern 0 -1)))
-	      (when migemo-use-pattern-alist
-		(setq migemo-pattern-alist
-		      (cons (cons word pattern) migemo-pattern-alist))
-		(when (and migemo-pattern-alist-length
-			   (> (length migemo-pattern-alist)
-			      (* migemo-pattern-alist-length 2)))
-		  (setcdr (nthcdr (1- (* migemo-pattern-alist-length 2))
-				  migemo-pattern-alist) nil)))
-	      pattern)))
+        (cond
+         ((setq freq (and migemo-use-frequent-pattern-alist
+                  (assoc word migemo-frequent-pattern-alist)))
+          (cdr freq))
+         ((setq alst (and migemo-use-pattern-alist
+                  (assoc word migemo-pattern-alist)))
+          (setq migemo-pattern-alist (cons alst (delq alst migemo-pattern-alist)))
+          (cdr alst))
+         (t
+          (with-current-buffer (process-buffer migemo-process)
+        (delete-region (point-min) (point-max))
+        (process-send-string migemo-process (concat word "\n"))
+        (while (not (and (> (point-max) 1)
+                 (eq (char-after (1- (point-max))) ?\n)))
+          (accept-process-output migemo-process
+                     0 migemo-accept-process-output-timeout-msec))
+        (setq pattern (buffer-substring (point-min) (1- (point-max)))))
+          (when (and (memq system-type '(windows-nt OS/2 emx))
+             (> (length pattern) 1)
+             (eq ?\r (aref pattern (1- (length pattern)))))
+        (setq pattern (substring pattern 0 -1)))
+          (when migemo-use-pattern-alist
+        (setq migemo-pattern-alist
+              (cons (cons word pattern) migemo-pattern-alist))
+        (when (and migemo-pattern-alist-length
+               (> (length migemo-pattern-alist)
+                  (* migemo-pattern-alist-length 2)))
+          (setcdr (nthcdr (1- (* migemo-pattern-alist-length 2))
+                  migemo-pattern-alist) nil)))
+          pattern)))
       (if (and migemo-after-conv-function
-	       (functionp migemo-after-conv-function))
-	  (funcall migemo-after-conv-function word pattern)
-	(migemo-replace-in-string pattern "\a" migemo-white-space-regexp))))))
+           (functionp migemo-after-conv-function))
+      (funcall migemo-after-conv-function word pattern)
+    (migemo-replace-in-string pattern "\a" migemo-white-space-regexp))))))
 
 (defun migemo-pattern-alist-load (file)
   "Load migemo alist file."
@@ -312,24 +302,24 @@
   "Save migemo alist file."
   (interactive)
   (when (and migemo-use-pattern-alist
-	     migemo-pattern-alist-file
-	     (or migemo-pattern-alist clear))
+         migemo-pattern-alist-file
+         (or migemo-pattern-alist clear))
     (let ((file (expand-file-name migemo-pattern-alist-file)))
       (when (file-writable-p file)
-	(when clear
-	  (setq migemo-pattern-alist nil))
-	(when (and migemo-pattern-alist-length
-		   (> (length migemo-pattern-alist) migemo-pattern-alist-length))
-	  (setcdr (nthcdr (1- migemo-pattern-alist-length)
-			  migemo-pattern-alist) nil))
-	(with-temp-buffer
-	  (let ((coding-system-for-write migemo-coding-system)
+    (when clear
+      (setq migemo-pattern-alist nil))
+    (when (and migemo-pattern-alist-length
+           (> (length migemo-pattern-alist) migemo-pattern-alist-length))
+      (setcdr (nthcdr (1- migemo-pattern-alist-length)
+              migemo-pattern-alist) nil))
+    (with-temp-buffer
+      (let ((coding-system-for-write migemo-coding-system)
                 (buffer-file-coding-system migemo-coding-system))
             (if (fboundp 'pp)
                 (pp migemo-pattern-alist (current-buffer))
               (prin1 migemo-pattern-alist (current-buffer)))
             (write-region (point-min) (point-max) file nil 'nomsg)))
-	(setq migemo-pattern-alist nil)))))
+    (setq migemo-pattern-alist nil)))))
 
 (defun migemo-kill ()
   "Kill migemo process"
@@ -355,33 +345,33 @@
     (migemo-kill)
     (migemo-init)
     (let ((file (expand-file-name migemo-frequent-pattern-alist-file))
-	  (migemo-use-pattern-alist nil)
-	  (migemo-use-frequent-pattern-alist nil)
-	  (migemo-after-conv-function (lambda (_x y) y))
-	  word)
+      (migemo-use-pattern-alist nil)
+      (migemo-use-frequent-pattern-alist nil)
+      (migemo-after-conv-function (lambda (_x y) y))
+      word)
       (setq migemo-frequent-pattern-alist nil)
       (with-temp-buffer
         (let ((coding-system-for-write migemo-coding-system)
               (buffer-file-coding-system migemo-coding-system)))
-	(insert-file-contents fcfile)
-	(goto-char (point-min))
-	(message "Make frequently pattern...")
-	(while (not (eobp))
-	  (when (looking-at "^[a-z]+$")
-	    (setq word (match-string 0))
-	    (message "Make frequently pattern...%s" word)
-	    (setq migemo-frequent-pattern-alist
-		  (cons (cons word (migemo-get-pattern word))
-			migemo-frequent-pattern-alist)))
-	  (forward-line 1))
-	(when (file-writable-p file)
-	  (setq migemo-frequent-pattern-alist
-		(nreverse migemo-frequent-pattern-alist))
-	  (erase-buffer)
-	  (if (fboundp 'pp)
-	      (pp migemo-frequent-pattern-alist (current-buffer))
-	    (prin1 migemo-frequent-pattern-alist (current-buffer)))
-	  (write-region (point-min) (point-max) file nil 'nomsg)))
+    (insert-file-contents fcfile)
+    (goto-char (point-min))
+    (message "Make frequently pattern...")
+    (while (not (eobp))
+      (when (looking-at "^[a-z]+$")
+        (setq word (match-string 0))
+        (message "Make frequently pattern...%s" word)
+        (setq migemo-frequent-pattern-alist
+          (cons (cons word (migemo-get-pattern word))
+            migemo-frequent-pattern-alist)))
+      (forward-line 1))
+    (when (file-writable-p file)
+      (setq migemo-frequent-pattern-alist
+        (nreverse migemo-frequent-pattern-alist))
+      (erase-buffer)
+      (if (fboundp 'pp)
+          (pp migemo-frequent-pattern-alist (current-buffer))
+        (prin1 migemo-frequent-pattern-alist (current-buffer)))
+      (write-region (point-min) (point-max) file nil 'nomsg)))
       (migemo-kill)
       (migemo-init)
       (message "Make frequently pattern...done"))))
@@ -393,10 +383,10 @@ into the migemo's regexp pattern."
   (let ((pos (point)))
     (goto-char (- pos 1))
     (if (re-search-backward "[^-a-zA-Z]" (line-beginning-position) t)
-	(forward-char 1)
+    (forward-char 1)
       (beginning-of-line))
     (let* ((str (buffer-substring-no-properties (point) pos))
-	   (jrpat (migemo-get-pattern str)))
+       (jrpat (migemo-get-pattern str)))
       (delete-region (point) pos)
       (insert jrpat))))
 
@@ -415,14 +405,14 @@ into the migemo's regexp pattern."
   (if (null migemo-do-isearch)
       (search-backward-regexp migemo-search-pattern bound noerror count)
     (or (and (not (eq this-command 'isearch-repeat-backward))
-	     (not (get-char-property (point) 'invisible (current-buffer)))
-	     (or (and (looking-at migemo-search-pattern)
-		      (match-beginning 0))
-		 (and (not (eq (point) (point-min)))
-		      (progn (forward-char -1)
-			     (and (looking-at migemo-search-pattern)
-				  (match-beginning 0))))))
-	(search-backward-regexp migemo-search-pattern bound noerror count))))
+         (not (get-char-property (point) 'invisible (current-buffer)))
+         (or (and (looking-at migemo-search-pattern)
+              (match-beginning 0))
+         (and (not (eq (point) (point-min)))
+              (progn (forward-char -1)
+                 (and (looking-at migemo-search-pattern)
+                  (match-beginning 0))))))
+    (search-backward-regexp migemo-search-pattern bound noerror count))))
 
 ;; experimental
 ;; (define-key global-map "\M-;" 'migemo-dabbrev-expand)
@@ -452,75 +442,72 @@ into the migemo's regexp pattern."
 (defun migemo-dabbrev-expand ()
   (interactive)
   (let ((end-pos (point))
-	matched-start matched-string)
+    matched-start matched-string)
     (if (eq last-command this-command)
-	(goto-char migemo-dabbrev-search-point)
+    (goto-char migemo-dabbrev-search-point)
       (goto-char (- end-pos 1))
       (if (re-search-backward "[^a-z-]" (line-beginning-position) t)
-	  (forward-char 1)
-	(beginning-of-line))
+      (forward-char 1)
+    (beginning-of-line))
       (setq migemo-search-pattern-alist nil)
       (setq migemo-dabbrev-start-point (point))
       (setq migemo-dabbrev-search-point (point))
       (setq migemo-dabbrev-pattern
-	    (buffer-substring-no-properties (point) end-pos))
+        (buffer-substring-no-properties (point) end-pos))
       (setq migemo-dabbrev-pre-patterns nil))
     (if (catch 'found
-	  (while (if (> migemo-dabbrev-search-point migemo-dabbrev-start-point)
-		     (and (migemo-forward migemo-dabbrev-pattern (point-max) t)
-			  (setq migemo-dabbrev-search-point (match-end 0)))
-		   (if (migemo-backward migemo-dabbrev-pattern (point-min) t)
-		       (setq migemo-dabbrev-search-point (match-beginning 0))
-		     (goto-char migemo-dabbrev-start-point)
-		     (forward-word 1)
-		     (message (format "Trun back for `%s'" migemo-dabbrev-pattern))
-		     (and (migemo-forward migemo-dabbrev-pattern (point-max) t)
-			  (setq migemo-dabbrev-search-point (match-end 0)))))
-	    (setq matched-start (match-beginning 0))
-	    (unless (re-search-forward ".\\>" (line-end-position) t)
-	      (end-of-line))
-	    (setq matched-string (buffer-substring-no-properties matched-start (point)))
-	    (unless (member matched-string migemo-dabbrev-pre-patterns)
-	      (let ((matched-end (point))
-		    (str (copy-sequence matched-string))
-		    lstart lend)
-		(if (and (pos-visible-in-window-p matched-start)
-			 (pos-visible-in-window-p matched-end))
-		    (progn
-		      (if migemo-dabbrev-ol
-			  (move-overlay migemo-dabbrev-ol matched-start (point))
-			(setq migemo-dabbrev-ol (make-overlay matched-start (point))))
-		      (overlay-put migemo-dabbrev-ol 'evaporate t)
-		      (overlay-put migemo-dabbrev-ol 'face migemo-dabbrev-ol-face))
-		  (when migemo-dabbrev-ol
-		    (delete-overlay migemo-dabbrev-ol))
-		  (when migemo-dabbrev-display-message
-		    (save-excursion
-		      (save-restriction
-			(goto-char matched-start)
-			(setq lstart (progn (beginning-of-line) (point)))
-			(setq lend (progn (end-of-line) (point)))
-			(if migemo-emacs21p
-			    (put-text-property 0 (length str)
-					       'face migemo-dabbrev-ol-face str)
-			  (setq str (concat "°⁄" str "°€")))
-			(message "(%d): %s%s%s"
-				 (count-lines (point-min) matched-start)
-				 (buffer-substring-no-properties lstart matched-start)
-				 str
-				 (buffer-substring-no-properties matched-end lend)))))))
-	      (throw 'found t))
-	    (goto-char migemo-dabbrev-search-point)))
-	(progn
-	  (setq migemo-dabbrev-pre-patterns
-		(cons matched-string migemo-dabbrev-pre-patterns))
-	  (delete-region migemo-dabbrev-start-point end-pos)
-	  (forward-char 1)
-	  (goto-char migemo-dabbrev-start-point)
-	  (insert matched-string))
+      (while (if (> migemo-dabbrev-search-point migemo-dabbrev-start-point)
+             (and (migemo-forward migemo-dabbrev-pattern (point-max) t)
+              (setq migemo-dabbrev-search-point (match-end 0)))
+           (if (migemo-backward migemo-dabbrev-pattern (point-min) t)
+               (setq migemo-dabbrev-search-point (match-beginning 0))
+             (goto-char migemo-dabbrev-start-point)
+             (forward-word 1)
+             (message (format "Trun back for `%s'" migemo-dabbrev-pattern))
+             (and (migemo-forward migemo-dabbrev-pattern (point-max) t)
+              (setq migemo-dabbrev-search-point (match-end 0)))))
+        (setq matched-start (match-beginning 0))
+        (unless (re-search-forward ".\\>" (line-end-position) t)
+          (end-of-line))
+        (setq matched-string (buffer-substring-no-properties matched-start (point)))
+        (unless (member matched-string migemo-dabbrev-pre-patterns)
+          (let ((matched-end (point))
+            (str (copy-sequence matched-string))
+            lstart lend)
+        (if (and (pos-visible-in-window-p matched-start)
+             (pos-visible-in-window-p matched-end))
+            (progn
+              (if migemo-dabbrev-ol
+              (move-overlay migemo-dabbrev-ol matched-start (point))
+            (setq migemo-dabbrev-ol (make-overlay matched-start (point))))
+              (overlay-put migemo-dabbrev-ol 'evaporate t)
+              (overlay-put migemo-dabbrev-ol 'face migemo-dabbrev-ol-face))
+          (when migemo-dabbrev-ol
+            (delete-overlay migemo-dabbrev-ol))
+          (when migemo-dabbrev-display-message
+            (save-excursion
+              (save-restriction
+            (goto-char matched-start)
+            (setq lstart (progn (beginning-of-line) (point)))
+            (setq lend (progn (end-of-line) (point)))
+            (setq str (concat "„Äê" str "„Äë"))
+            (message "(%d): %s%s%s"
+                 (count-lines (point-min) matched-start)
+                 (buffer-substring-no-properties lstart matched-start)
+                 str
+                 (buffer-substring-no-properties matched-end lend)))))))
+          (throw 'found t))
+        (goto-char migemo-dabbrev-search-point)))
+    (progn
+      (setq migemo-dabbrev-pre-patterns
+        (cons matched-string migemo-dabbrev-pre-patterns))
+      (delete-region migemo-dabbrev-start-point end-pos)
+      (forward-char 1)
+      (goto-char migemo-dabbrev-start-point)
+      (insert matched-string))
       (goto-char end-pos)
       (message (format "No dynamic expansion for `%s' found"
-		       migemo-dabbrev-pattern)))
+               migemo-dabbrev-pattern)))
     (add-hook 'pre-command-hook 'migemo-dabbrev-expand-done)))
 
 (defsubst migemo--isearch-regexp-function ()
@@ -540,7 +527,7 @@ into the migemo's regexp pattern."
   "adviced by migemo."
   (let ((isearch-adjusted isearch-adjusted))
     (when (and migemo-isearch-enable-p
-	       (not isearch-forward) (not isearch-regexp) (not (migemo--isearch-regexp-function)))
+           (not isearch-forward) (not isearch-regexp) (not (migemo--isearch-regexp-function)))
       ;; don't use 'looking-at'
       (setq isearch-adjusted t))
     ad-do-it))
@@ -549,19 +536,19 @@ into the migemo's regexp pattern."
   "adviced by migemo."
   (if migemo-do-isearch
       (setq ad-return-value
-	    (migemo-forward (ad-get-arg 0) (ad-get-arg 1) (ad-get-arg 2) (ad-get-arg 3)))
+        (migemo-forward (ad-get-arg 0) (ad-get-arg 1) (ad-get-arg 2) (ad-get-arg 3)))
     ad-do-it))
 
 (defadvice search-backward (around migemo-search-ad activate)
   "adviced by migemo."
   (if migemo-do-isearch
       (setq ad-return-value
-	    (migemo-backward (ad-get-arg 0) (ad-get-arg 1) (ad-get-arg 2) (ad-get-arg 3)))
+        (migemo-backward (ad-get-arg 0) (ad-get-arg 1) (ad-get-arg 2) (ad-get-arg 3)))
     ad-do-it))
 
 (when (and (boundp 'isearch-regexp-lax-whitespace)
-	   (fboundp 're-search-forward-lax-whitespace)
-	   (fboundp 'search-forward-lax-whitespace))
+       (fboundp 're-search-forward-lax-whitespace)
+       (fboundp 'search-forward-lax-whitespace))
   (setq isearch-search-fun-function 'isearch-search-fun-migemo)
 
   (when (fboundp 'isearch-search-fun-default)
@@ -573,43 +560,43 @@ into the migemo's regexp pattern."
                  (funcall ,ad-return-value string bound noerror))))))
 
   (defun isearch-search-fun-migemo ()
-	"Return default functions to use for the search with migemo."
-	(cond
-	 ((migemo--isearch-regexp-function)
-	  (lambda (string &optional bound noerror count)
-	;; Use lax versions to not fail at the end of the word while
-	;; the user adds and removes characters in the search string
-	;; (or when using nonincremental word isearch)
-	(let* ((state-string-func (if (fboundp 'isearch--state-string)
-				      'isearch--state-string
-				    'isearch-string-state))
+    "Return default functions to use for the search with migemo."
+    (cond
+     ((migemo--isearch-regexp-function)
+      (lambda (string &optional bound noerror count)
+    ;; Use lax versions to not fail at the end of the word while
+    ;; the user adds and removes characters in the search string
+    ;; (or when using nonincremental word isearch)
+    (let* ((state-string-func (if (fboundp 'isearch--state-string)
+                      'isearch--state-string
+                    'isearch-string-state))
                (lax (not (or isearch-nonincremental
-				(eq (length isearch-string)
-				(length (funcall state-string-func (car isearch-cmds))))))))
-	  (funcall
-	   (if isearch-forward #'re-search-forward #'re-search-backward)
-	   (if (functionp (migemo--isearch-regexp-function))
-		   (funcall (migemo--isearch-regexp-function) string lax)
-		 (word-search-regexp string lax))
-	   bound noerror count))))
-	 ((and isearch-regexp isearch-regexp-lax-whitespace
-	   search-whitespace-regexp)
-	  (if isearch-forward
-	  're-search-forward-lax-whitespace
-	're-search-backward-lax-whitespace))
-	 (isearch-regexp
-	  (if isearch-forward 're-search-forward 're-search-backward))
-	 ((and (if (boundp 'isearch-lax-whitespace) isearch-lax-whitespace t)
+                (eq (length isearch-string)
+                (length (funcall state-string-func (car isearch-cmds))))))))
+      (funcall
+       (if isearch-forward #'re-search-forward #'re-search-backward)
+       (if (functionp (migemo--isearch-regexp-function))
+           (funcall (migemo--isearch-regexp-function) string lax)
+         (word-search-regexp string lax))
+       bound noerror count))))
+     ((and isearch-regexp isearch-regexp-lax-whitespace
+       search-whitespace-regexp)
+      (if isearch-forward
+      're-search-forward-lax-whitespace
+    're-search-backward-lax-whitespace))
+     (isearch-regexp
+      (if isearch-forward 're-search-forward 're-search-backward))
+     ((and (if (boundp 'isearch-lax-whitespace) isearch-lax-whitespace t)
                search-whitespace-regexp migemo-do-isearch)
-	  (if isearch-forward 'migemo-forward 'migemo-backward))
-	 ((and (if (boundp 'isearch-lax-whitespace) isearch-lax-whitespace t)
+      (if isearch-forward 'migemo-forward 'migemo-backward))
+     ((and (if (boundp 'isearch-lax-whitespace) isearch-lax-whitespace t)
                search-whitespace-regexp)
-	  (if isearch-forward 'search-forward-lax-whitespace
-	'search-backward-lax-whitespace))
-	 (migemo-do-isearch
-	  (if isearch-forward 'migemo-forward 'migemo-backward))
-	 (t
-	  (if isearch-forward 'search-forward 'search-backward))))
+      (if isearch-forward 'search-forward-lax-whitespace
+    'search-backward-lax-whitespace))
+     (migemo-do-isearch
+      (if isearch-forward 'migemo-forward 'migemo-backward))
+     (t
+      (if isearch-forward 'search-forward 'search-backward))))
   )
 
 ;; Turn off input-method automatically when C-s or C-r are typed.
@@ -618,13 +605,13 @@ into the migemo's regexp pattern."
   (setq migemo-search-pattern nil)
   (setq migemo-search-pattern-alist nil)
   (when (and migemo-isearch-enable-p
-	     (boundp 'current-input-method))
+         (boundp 'current-input-method))
     (setq migemo-current-input-method current-input-method)
     (setq migemo-current-input-method-title current-input-method-title)
     (setq migemo-input-method-function input-method-function)
     (when (and migemo-mw32-input-method
-	       (stringp migemo-current-input-method)
-	       (string= migemo-current-input-method migemo-mw32-input-method))
+           (stringp migemo-current-input-method)
+           (string= migemo-current-input-method migemo-mw32-input-method))
       (set-input-method nil))
     (setq current-input-method nil)
     (setq current-input-method-title nil)
@@ -641,10 +628,10 @@ into the migemo's regexp pattern."
   (setq migemo-search-pattern nil)
   (setq migemo-search-pattern-alist nil)
   (when (and migemo-isearch-enable-p
-	     (boundp 'current-input-method))
+         (boundp 'current-input-method))
     (when (and migemo-mw32-input-method
-	       (stringp migemo-current-input-method)
-	       (string= migemo-current-input-method migemo-mw32-input-method))
+           (stringp migemo-current-input-method)
+           (string= migemo-current-input-method migemo-mw32-input-method))
       (set-input-method migemo-current-input-method))
     (let ((state-changed-p (not (equal current-input-method migemo-current-input-method))))
       (setq current-input-method migemo-current-input-method)
@@ -666,11 +653,9 @@ into the migemo's regexp pattern."
 (defadvice isearch-message-prefix (after migemo-status activate)
   "adviced by migemo."
   (let ((ret ad-return-value)
-	(str "[MIGEMO]"))
-    (when migemo-emacs21p
-      (put-text-property 0 (length str) 'face migemo-message-prefix-face str))
+    (str "[MIGEMO]"))
     (when (and migemo-isearch-enable-p
-	       (not (or isearch-regexp (migemo--isearch-regexp-function))))
+               (not (or isearch-regexp (migemo--isearch-regexp-function))))
       (setq ad-return-value (concat str " " ret)))))
 
 ;;;; for isearch-lazy-highlight (Emacs 21)
@@ -700,17 +685,17 @@ into the migemo's regexp pattern."
 ;;;; for isearch-highlightify-region (XEmacs 21)
 (when (fboundp 'isearch-highlightify-region)
   (defadvice isearch-highlightify-region (around migemo-highlightify-region
-						 activate)
+                         activate)
     "adviced by migemo."
     (if migemo-isearch-enable-p
-	(let ((isearch-string (migemo-search-pattern-get isearch-string))
-	      (isearch-regexp t))
-	  ad-do-it)
+    (let ((isearch-string (migemo-search-pattern-get isearch-string))
+          (isearch-regexp t))
+      ad-do-it)
       ad-do-it)))
 
 ;; supports C-w C-d for GNU emacs only [migemo:00171]
 (when (and (not (featurep 'xemacs))
-	   (fboundp 'isearch-yank-line))
+       (fboundp 'isearch-yank-line))
   (defun migemo-register-isearch-keybinding ()
     (define-key isearch-mode-map "\C-d" 'migemo-isearch-yank-char)
     (define-key isearch-mode-map "\C-w" 'migemo-isearch-yank-word)
@@ -727,10 +712,10 @@ into the migemo's regexp pattern."
       (setq migemo-isearch-enable-p (not migemo-isearch-enable-p)))
     (when (fboundp 'isearch-lazy-highlight-new-loop)
       (let ((isearch-lazy-highlight-last-string nil))
-	(condition-case nil
-	    (isearch-lazy-highlight-new-loop)
-	  (error
-	   (isearch-lazy-highlight-new-loop nil nil)))))
+    (condition-case nil
+        (isearch-lazy-highlight-new-loop)
+      (error
+       (isearch-lazy-highlight-new-loop nil nil)))))
     (isearch-message))
 
   (defun migemo-isearch-yank-char ()
@@ -742,13 +727,13 @@ into the migemo's regexp pattern."
                             isearch-other-end (point)))
       (setq isearch-message isearch-string))
     (let ((search-upper-case (unless migemo-isearch-enable-p
-			       search-upper-case)))
+                   search-upper-case)))
       (isearch-yank-string
        (save-excursion
-	 (and (not isearch-forward) isearch-other-end
-	      (goto-char isearch-other-end))
-	 (buffer-substring-no-properties (point)
-					 (progn (forward-char 1) (point)))))))
+     (and (not isearch-forward) isearch-other-end
+          (goto-char isearch-other-end))
+     (buffer-substring-no-properties (point)
+                     (progn (forward-char 1) (point)))))))
 
   (defun migemo-isearch-yank-word ()
     "Pull next character from buffer into search string with migemo."
@@ -759,13 +744,13 @@ into the migemo's regexp pattern."
                             isearch-other-end (point)))
       (setq isearch-message isearch-string))
     (let ((search-upper-case (unless migemo-isearch-enable-p
-			       search-upper-case)))
+                   search-upper-case)))
       (isearch-yank-string
        (save-excursion
-	 (and (not isearch-forward) isearch-other-end
-	      (goto-char isearch-other-end))
-	 (buffer-substring-no-properties (point)
-					 (progn (forward-word 1) (point)))))))
+     (and (not isearch-forward) isearch-other-end
+          (goto-char isearch-other-end))
+     (buffer-substring-no-properties (point)
+                     (progn (forward-word 1) (point)))))))
 
   (defun migemo-isearch-yank-line ()
     "Pull next character from buffer into search string with migemo."
@@ -776,13 +761,13 @@ into the migemo's regexp pattern."
                             isearch-other-end (point)))
       (setq isearch-message isearch-string))
     (let ((search-upper-case (unless migemo-isearch-enable-p
-			       search-upper-case)))
+                   search-upper-case)))
       (isearch-yank-string
        (save-excursion
-	 (and (not isearch-forward) isearch-other-end
-	      (goto-char isearch-other-end))
-	 (buffer-substring-no-properties (point)
-					 (line-end-position))))))
+     (and (not isearch-forward) isearch-other-end
+          (goto-char isearch-other-end))
+     (buffer-substring-no-properties (point)
+                     (line-end-position))))))
 )
 
 (add-hook 'kill-emacs-hook 'migemo-pattern-alist-save)
@@ -790,10 +775,10 @@ into the migemo's regexp pattern."
 (provide 'migemo)
 
 ;; sample
-;; 0123 abcd ABCD §“§È§¨§  •´•ø•´•  ¥¡ª˙ !"[#\$]%^&_':`(;)<*=+>,?-@./{|}~
+;; 0123 abcd ABCD „Å≤„Çâ„Åå„Å™ „Ç´„Çø„Ç´„Éä Êº¢Â≠ó !"[#\$]%^&_':`(;)<*=+>,?-@./{|}~
 
 ;; Local Variables:
-;; coding: euc-japan-unix
+;; coding: utf-8
 ;; indent-tabs-mode: nil
 ;; End:
 

--- a/migemo.el
+++ b/migemo.el
@@ -627,10 +627,6 @@ into the migemo's regexp pattern."
   (setq migemo-search-pattern-alist nil)
   (when (and migemo-isearch-enable-p
          (boundp 'current-input-method))
-    (when (and migemo-mw32-input-method
-           (stringp migemo-current-input-method)
-           (string= migemo-current-input-method migemo-mw32-input-method))
-      (set-input-method migemo-current-input-method))
     (let ((state-changed-p (not (equal current-input-method migemo-current-input-method))))
       (setq current-input-method migemo-current-input-method)
       (setq current-input-method-title migemo-current-input-method-title)

--- a/migemo.el
+++ b/migemo.el
@@ -59,7 +59,7 @@
 ;; (setq migemo-options '("-S" "migemo" "-t" "emacs" "-i" "\a"))
 ;; (setq migemo-dictionary "somewhere/migemo/utf-8/migemo-dict")
 ;; (setq migemo-user-dictionary nil)
-;; (setq migemo-regex-dictionary nil))
+;; (setq migemo-regex-dictionary nil)
 
 (defcustom migemo-directory nil
   "*Directory where migemo files are placed."
@@ -129,12 +129,14 @@
   :group 'migemo
   :type 'integer)
 
-(defcustom migemo-pattern-alist-file (expand-file-name ".migemo-pattern" user-emacs-directory)
+(defcustom migemo-pattern-alist-file
+  (locate-user-emacs-file "migemo-pattern" ".migemo-pattern")
   "*Path of migemo alist file. If nil, don't save and restore the file."
   :group 'migemo
   :type 'file)
 
-(defcustom migemo-frequent-pattern-alist-file (expand-file-name ".migemo-frequent" user-emacs-directory)
+(defcustom migemo-frequent-pattern-alist-file
+  (locate-user-emacs-file "migemo-frequent" ".migemo-freqent")
   "*Path of migemo frequent alist file. If nil, don't save and restore the file."
   :group 'migemo
   :type 'file)
@@ -609,10 +611,6 @@ into the migemo's regexp pattern."
     (setq migemo-current-input-method current-input-method)
     (setq migemo-current-input-method-title current-input-method-title)
     (setq migemo-input-method-function input-method-function)
-    (when (and migemo-mw32-input-method
-           (stringp migemo-current-input-method)
-           (string= migemo-current-input-method migemo-mw32-input-method))
-      (set-input-method nil))
     (setq current-input-method nil)
     (setq current-input-method-title nil)
     (setq input-method-function nil)


### PR DESCRIPTION
* Change Encoding: from euc-jp-unix to utf-8-unix
* Drop Emacs21, XEmacs feature (not yet completed).
* Change location ".migemo-(pattern|frequent)"  under `user-emacs-directory'.

Signed-off-by: Youhei SASAKI <uwabami@gfd-dennou.org>