### PR TITLE
Use advice macros instead of defadvice

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        emacs_version:
+          - 25.3
+          - 30.1
+          - snapshot
+    steps:
+    - uses: purcell/setup-emacs@master
+      with:
+        version: ${{ matrix.emacs_version }}
+
+    - uses: actions/checkout@v4
+    - name: Install dependencies
+      run: sudo apt install -y cmigemo
+    - name: Run tests
+      run: |
+        make clean
+        make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.PHONY : test
+
+EMACS ?= emacs
+
+test:
+	$(EMACS) -Q -batch -L . -L test \
+		-l test/migemo-test.el \
+		-f ert-run-tests-batch-and-exit
+
+.PHONY: clean
+clean:
+	-rm -f *.elc *~

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# migemo.el
+# migemo.el ![](https://github.com/emacs-jp/migemo/workflows/CI/badge.svg)
 
 migemo.el provides Japanese increment search with 'Romanization of Japanese'(ローマ字).
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ migemo.el provides Japanese increment search with 'Romanization of Japanese'(ロ
 
 ## Requirements
 
-* Emacs 24 or higher.
-* cl-lib.el
+* Emacs 25 or higher.
 * [cmigemo](https://github.com/koron/cmigemo) or [CVS Head migemo](http://0xcc.net/migemo/)
   * We recommend to use cmigemo. It is default since version 1.9.2
 

--- a/test/migemo-test.el
+++ b/test/migemo-test.el
@@ -1,0 +1,37 @@
+;;;; migemo-test.el --- Tests for migemo.el  -*- lexical-binding: t; -*-
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;; Code:
+
+(require 'ert)
+(require 'migemo)
+(require 'setup-migemo-test)
+
+(defvar migemo-test-str "これは migemo 検索のテストです。")
+
+(ert-deftest migemo-test-roma/kanji ()
+  (should (equal 11 (string-match (migemo-search-pattern-get "kensaku") migemo-test-str))))
+
+(ert-deftest migemo-test-eng/kana ()
+  (should (equal 14 (string-match (migemo-search-pattern-get "test") migemo-test-str))))
+
+(ert-deftest migemo-test-notfound ()
+  (should-not (string-match (migemo-search-pattern-get "tokyo") migemo-test-str)))
+
+;; migemo-test.el ends here

--- a/test/setup-migemo-test.el
+++ b/test/setup-migemo-test.el
@@ -1,0 +1,13 @@
+;; parameters for ubuntu and cmigemo package
+(when (and (executable-find "cmigemo")
+           (file-exists-p "/usr/share/cmigemo/utf-8/migemo-dict"))
+  (setq migemo-command "cmigemo"
+        migemo-options '("-q" "--emacs")
+        migemo-dictionary "/usr/share/cmigemo/utf-8/migemo-dict"
+        migemo-user-dictionary nil
+        migemo-regex-dictionary nil
+        migemo-coding-system 'utf-8-unix))
+
+(migemo-init)
+
+(provide 'setup-migemo-test)


### PR DESCRIPTION
- Update minimum emacs version to use advice macros
- Drop XEmacs supports
- Remove needless emacs version checks

See #29, #25
