### PR TITLE
Modify isearch message prefix

### DIFF
--- a/migemo.el
+++ b/migemo.el
@@ -623,9 +623,10 @@ into the migemo's regexp pattern."
 
 (defun migemo--isearch-message-prefix (orig-val)
   (let ((str "[MIGEMO]"))
-    (when (and migemo-isearch-enable-p
-               (not (or isearch-regexp (migemo--isearch-regexp-function))))
-      (concat str " " orig-val))))
+    (if (and migemo-isearch-enable-p
+             (not (or isearch-regexp (migemo--isearch-regexp-function))))
+        (concat str " " orig-val)
+      orig-val)))
 (advice-add 'isearch-message-prefix :filter-return #'migemo--isearch-message-prefix)
 
 (defun migemo--isearch-lazy-highlight-new-loop (orig-fun &rest args)

--- a/migemo.el
+++ b/migemo.el
@@ -622,7 +622,7 @@ into the migemo's regexp pattern."
   :type 'face)
 
 (defun migemo--isearch-message-prefix (orig-val)
-  (let ((str "[MIGEMO]"))
+  (let ((str (propertize "[MIGEMO]" 'face migemo-message-prefix-face)))
     (if (and migemo-isearch-enable-p
              (not (or isearch-regexp (migemo--isearch-regexp-function))))
         (concat str " " orig-val)


### PR DESCRIPTION
* migemoを使わない場合に、isearch message prefixが消えてしまうようになっていたので、修正してみました。
* `migemo-message-prefix-face`をisearch message prefixの"[MIGEMO]"の部分に適用し、見た目を変えられるようにしてみました。